### PR TITLE
fix: use mode prop in configMap items, rather than defaultMode

### DIFF
--- a/spec/behavior/expressionParser.spec.js
+++ b/spec/behavior/expressionParser.spec.js
@@ -79,12 +79,12 @@ describe('Expression Parser', function () {
             name: 'test',
             items: [
               {
-                defaultMode: 436,
+                mode: 436,
                 key: 'file1.txt',
                 path: 'subdir/file.txt'
               },
               {
-                defaultMode: 256,
+                mode: 256,
                 key: 'file2.txt',
                 path: 'file2.txt'
               }

--- a/src/expressionParser.js
+++ b/src/expressionParser.js
@@ -511,18 +511,18 @@ function parseVolume (name, expression) {
           if (/:/.test(set.path)) {
             let octal
             [set.path, octal] = set.path.split(':')
-            set.defaultMode = parseInt(octal, 8)
-            if (set.defaultMode > mode) {
-              mode = set.defaultMode
+            set.mode = parseInt(octal, 8)
+            if (set.mode > mode) {
+              mode = set.mode
             }
           }
         } else if (/:/.test(set.key)) {
           let octal
           [set.key, octal] = set.key.split(':')
           set.path = set.key
-          set.defaultMode = parseInt(octal, 8)
-          if (set.defaultMode > mode) {
-            mode = set.defaultMode
+          set.mode = parseInt(octal, 8)
+          if (set.mode > mode) {
+            mode = set.mode
           }
         }
         return set


### PR DESCRIPTION
Setting the mode for a configMap file seems to have broken in later k8s versions. I think later k8s versions are more strict about stray properties.