### PR TITLE
support `self` shorthand in deployment affinities

### DIFF
--- a/spec/integration/source/affinities/test/affinity.toml
+++ b/spec/integration/source/affinities/test/affinity.toml
@@ -26,6 +26,12 @@ image = "pretend/bash:1.0.0"
   [[affinity.pod.match]]
     In = { name = "heavyProcess"}
 
+[[affinity.pod]]
+  type = "soft"
+  weight = -1
+  [[affinity.pod.match]]
+    In = "self"
+
 # TODO: These are unimplemented samples for node affinity
 #[[affinity.node]]
 #  type = "soft"

--- a/spec/integration/verify/affinities/basicPod/test/deployment.yml
+++ b/spec/integration/verify/affinities/basicPod/test/deployment.yml
@@ -65,6 +65,15 @@ spec:
                       values:
                         - heavyProcess
                 topologyKey: kubernetes.io/hostname
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                        - test
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: test
           image: 'pretend/bash:1.0.0'

--- a/src/resources/affinity.js
+++ b/src/resources/affinity.js
@@ -48,6 +48,7 @@ const parsePreferredAffinity = R.map(x => {
 })
 const parseRequiredAffinity = R.compose(removeWeight, parsePreferredAffinity)
 
+// Returns a function which replaces { <AnyKey> : self } with { <AnyKey> : { name : some_name } }
 const createSelfResolver = (name) => R.lift(R.when(
   R.equals('self'), R.always({ name })
 ))
@@ -60,7 +61,10 @@ function createAffinities (cluster, config) {
   const affinities = {}
 
   // Resolve `self` references before creating structures to avoid having to
-  // pass config throughout every function
+  // pass config throughout every function.
+  // Create a resolver function using this deployment's `name`, then for every
+  // pod definition, for every `match` key, update the term to resolve `self`
+  // values without changing the key referring to it
   const resolveSelfToName = createSelfResolver(config.name)
   const affinitySources = R.map(R.over(R.lensProp('match'), R.map(resolveSelfToName)))(config.affinity.pod)
 


### PR DESCRIPTION
To avoid having to repeat the pod name in affinities, self can be used.
It will be translated to `name = <generated name>`.